### PR TITLE
added spellcheck for both English and German

### DIFF
--- a/src/electron/index.cjs
+++ b/src/electron/index.cjs
@@ -21,6 +21,7 @@ function createWindow() {
     // Load vite dev server page
     win.loadURL("http://localhost:5173/");
   }
+  win.webContents.session.setSpellCheckerLanguages(['en-US', 'de']);
 }
 
 ipcMain.on('saveMacros', (event, macros) => {


### PR DESCRIPTION
Name und Beschreibung werden auf deutsche und englische Rechtschreibung geprüft, das Befehlsfeld allerdings nicht, damit Befehle wie "npm run dev" nicht rot unterkringelt werden.